### PR TITLE
Multi host

### DIFF
--- a/composer.yaml
+++ b/composer.yaml
@@ -1,1 +1,0 @@
-includes: ['layer:docker', 'interface:etcd']

--- a/config.yaml
+++ b/config.yaml
@@ -7,3 +7,8 @@ options:
         compiled from the source identified by this tag in github. Using the
         value of "source" will use the master kubernetes branch when compiling
         the binaries.
+  cidr:
+    type: string
+    default: 10.1.0.0/16
+    description: |
+      Network CIDR to assign to K8s service groups

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,0 +1,1 @@
+includes: ['layer:docker', 'layer:flannel', 'interface:etcd']

--- a/reactive/k8s.py
+++ b/reactive/k8s.py
@@ -75,7 +75,7 @@ def download_kubectl():
     cmd = 'chmod +x /usr/local/bin/kubectl'
     check_call(split(cmd))
     set_state('kubectl.downloaded')
-    status_set('maintenance', 'Kubernetes installed')
+    status_set('active', 'Kubernetes installed')
 
 
 def render_files(reldata):

--- a/templates/master.json
+++ b/templates/master.json
@@ -21,7 +21,7 @@
       "command": [
               "/hyperkube",
               "apiserver",
-              "--portal-net=10.0.0.1/24",
+              "--portal-net={{cidr}}",
               "--address=0.0.0.0",
               "--etcd-servers={{connection_string}}",
               "--cluster-name=kubernetes",

--- a/templates/master.json
+++ b/templates/master.json
@@ -22,7 +22,7 @@
               "/hyperkube",
               "apiserver",
               "--portal-net=10.0.0.1/24",
-              "--address=127.0.0.1",
+              "--address=0.0.0.0",
               "--etcd-servers={{connection_string}}",
               "--cluster-name=kubernetes",
               "--v=2"


### PR DESCRIPTION
This is the core modification to K8's to support flannel networking. The overall implementation has been abstracted enough to be generic to most deployments.

There are a few things going on here we should be cognizant of:
- Networking CIDR applies to both the K8s services, and the flannel network configuration
- Any other layer implementation will need to follow the same guidelines, pass a cidr between both
- we're pulling containers from quay.io and gcr.io - both of which will not make it past the firewall test
- Once libnetwork takes over, this layer is likely to go away all together in favor of a unified libnetwork layer to configure the different providers

The flannel layer can be found [here](http://github.com/chuckbutler/flannel-layer)
