### PR TITLE
Removed a typo '.' in the args of the skydns container

### DIFF
--- a/templates/skydns-rc.yml
+++ b/templates/skydns-rc.yml
@@ -81,7 +81,7 @@ spec:
             cpu: 10m
             memory: 20Mi
         args:
-       {% if dns_domain -%}- -cmd=nslookup kubernetes.default.svc.{{ pillar['dns_domain'] }} localhost >/dev/null {% else %} - -cmd=nslookup kubernetes.default.svc.kubernetes.local localhost >/dev/null {% endif %}
+       {% if dns_domain -%}- -cmd=nslookup kubernetes.default.svc.{{ pillar['dns_domain'] }} localhost >/dev/null {% else %} - -cmd=nslookup kubernetes.default.svc.cluster.local localhost >/dev/null {% endif %}
         - -port=8080
         ports:
         - containerPort: 8080

--- a/templates/skydns-rc.yml
+++ b/templates/skydns-rc.yml
@@ -47,7 +47,7 @@ spec:
             memory: 50Mi
         args:
         # command = "/kube2sky"
-       {% if dns_domain -%}- -domain={{ dns_domain }} {% else %} - -domain=cluster.local {% endif %}
+       {% if dns_domain -%}- -domain={{ dns_domain }}. {% else %} - -domain=cluster.local. {% endif %}
         - -kube_master_url=http://{{private_address}}:8080
       - name: skydns
         image: gcr.io/google_containers/skydns:2015-03-11-001
@@ -57,9 +57,9 @@ spec:
             memory: 50Mi
         args:
         # command = "/skydns"
+       {% if dns_domain -%}- -domain={{ dns_domain }}. {% else %}  - -domain=cluster.local. {% endif %}
         - -machines=http://localhost:4001
         - -addr=0.0.0.0:53
-       {% if dns_domain -%}- -domain={{ dns_domain }} {% else %}  - -domain=cluster.local. {% endif %}
         ports:
         - containerPort: 53
           name: dns

--- a/templates/skydns-rc.yml
+++ b/templates/skydns-rc.yml
@@ -59,7 +59,7 @@ spec:
         # command = "/skydns"
         - -machines=http://localhost:4001
         - -addr=0.0.0.0:53
-       {% if dns_domain -%}- -domain={{ dns_domain }}. {% else %}  - -domain=cluster.local. {% endif %}
+       {% if dns_domain -%}- -domain={{ dns_domain }} {% else %}  - -domain=cluster.local. {% endif %}
         ports:
         - containerPort: 53
           name: dns


### PR DESCRIPTION
I have issued the problem with the kube-dns pod at github.com/kubernetes/kubernetes.git, but I was not able to label it.

In the mean time I got more information by looking at the previous logs of the skydns container.

```
kubectl logs -p kube-dns-v8-wvajz --namespace=kube-system -c skydns

2016/04/04 14:50:23 skydns: addr is invalid: bad port number 53 - -domain=cluster.local.
```

Looking at the code: there seems to be a typo in the skydnsrc.yaml file.

I have never done a pull request. So I tried it to learn something new.  I guess it worked out. 
I hope I have done this PR in the right github repository.
