### PR TITLE
Adds node workspace to the leader

### DIFF
--- a/reactive/k8s.py
+++ b/reactive/k8s.py
@@ -232,8 +232,12 @@ def master_kubeconfig():
     # Use a context manager to run the tar command in a specific directory.
     with chdir(directory):
         # Create a package with kubectl and the files to use it externally.
-        cmd = 'tar -cvzf /home/ubuntu/kubectl_package.tar.gz ca.crt client.crt client.key kubeconfig kubectl'  # noqa
+        cmd = 'tar -cvzf /home/ubuntu/kubectl_package.tar.gz ca.crt ' \
+              'client.key client.crt kubectl kubeconfig'
         check_call(split(cmd))
+
+    # This sets up the client workspace consistently on the leader and nodes.
+    node_kubeconfig()
     set_state('kubeconfig.created')
 
 


### PR DESCRIPTION
When testing kubernetes, the leader magically worked due to it hosting the apiserver bound to all interfaces on the host, listening on port 8080. This is not the case moving forward with how we've split apart leader and follower nodes.

This necessitates the creation, and usage of the "node workspace" - a la ~/.kube/config.
