### PR TITLE
move (master) to end of message for uniformity

### DIFF
--- a/reactive/k8s.py
+++ b/reactive/k8s.py
@@ -452,7 +452,7 @@ def render_files(reldata=None):
 def status_set(level, message):
     '''Output status message with leadership information.'''
     if is_leader():
-        message = '(master) {0}'.format(message)
+        message = '{0} (master)'.format(message)
     hookenv.status_set(level, message)
 
 


### PR DESCRIPTION
This changes the status output from:

```
kubernetes/0  active    idle   3        172.27.24.54    8088/tcp  Kubernetes running.
kubernetes/1  active    idle   4        172.27.24.55    6443/tcp  (master) Kubernetes services started
```

 to this:

```
kubernetes/0  active    idle   3        172.27.24.54    8088/tcp  Kubernetes running.
kubernetes/1  active    idle   4        172.27.24.55    6443/tcp  Kubernetes services started (master)
```
